### PR TITLE
Output error on build failure.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function createWatcher(destDir, interval) {
   });
 
   watcher.on('error', function(err) {
-    console.log(chalk.red('\n\nBuild failed.\n'));
+    console.log(chalk.red('\n\nBuild failed:\n\n' + err.toString()));
   });
 
   return watcher;

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "javascript"
   ],
   "dependencies": {
-    "broccoli-kitchen-sink-helpers": "~0.2.5",
-    "rimraf": "~2.2.8",
-    "chalk": "~0.5.1",
-    "broccoli": "~0.13.3"
+    "broccoli": "^0.16.2",
+    "broccoli-kitchen-sink-helpers": "^0.2.6",
+    "chalk": "^1.0.0",
+    "rimraf": "^2.3.2"
   },
   "devDependencies": {
-    "mocha": "~2.1.0",
-    "rimraf": "~2.2.8",
-    "expect.js": "~0.3.1"
+    "expect.js": "~0.3.1",
+    "mocha": "^2.2.4",
+    "rimraf": "^2.3.2"
   }
 }


### PR DESCRIPTION
It's hard to debug anything running under broccoli-timepiece, as the output is just 'Build failed'.

This tiny pull request addresses this by also printing out the error. It's non-optional as (from personal experience) debugging is massively improved by having a clue as to what the problem is!

Example:

```
Build failed:

/vagrant/website/tmp/tree_merger-tmp_dest_dir-J17yFk7I.tmp/contact.coffee:22
  $(win.document).ready -> new Contact('#container', config.apiHost, config.homeUrl).start()
                                                                                            ^
ParseError: unmatched OUTDENT
```

I tested this by running it in an existing project using broccoli-timepiece. Works fine.

There is an existing pr that does something similar: https://github.com/rwjblue/broccoli-timepiece/pull/8. @piotrpalek sorry for not building on it, but this pull request is based on head, and is simpler.

Thanks! 
