### PR TITLE
Add LiveReload server

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,28 +4,43 @@ var fs       = require('fs');
 var path     = require('path');
 var chalk    = require('chalk');
 var rimraf   = require('rimraf');
+var tinylr   = require('tiny-lr');
 var helpers  = require('broccoli-kitchen-sink-helpers');
 var Watcher  = require('broccoli/lib/watcher');
 var broccoli = require('broccoli');
 
-function createWatcher(destDir, interval) {
-  var tree    = broccoli.loadBrocfile();
-  var builder = new broccoli.Builder(tree);
-  var watcher = new Watcher(builder, {interval: interval || 100});
+function createWatcher(destDir, interval, lrPort) {
+  var tree     = broccoli.loadBrocfile();
+  var builder  = new broccoli.Builder(tree);
+  var watcher  = new Watcher(builder, {interval: interval || 100});
+  var lrServer = new tinylr.Server;
 
-  var atExit = function() { 
+  var atExit = function() {
     builder.cleanup()
       .then(function() {
         process.exit(1);
       });
   };
-  
+
+  var liveReload = function() {
+    // Chrome LiveReload doesn't seem to care about the specific files as long
+    // as we pass something.
+    lrServer.changed({body: {files: ['livereload_dummy']}})
+  };
+
   process.on('SIGINT', atExit);
   process.on('SIGTERM', atExit);
+
+  lrServer.listen(lrPort || 35729, function(err) {
+    if(err) {
+      throw err;
+    }
+  });
 
   watcher.on('change', function(results) {
     rimraf.sync(destDir);
     helpers.copyRecursivelySync(results.directory, destDir);
+    liveReload();
 
     console.log(chalk.green("Build successful - " + Math.floor(results.totalTime / 1e6) + 'ms'));
   });
@@ -37,4 +52,4 @@ function createWatcher(destDir, interval) {
   return watcher;
 }
 
-createWatcher(process.argv[2], process.argv[3]);
+createWatcher(process.argv[2], process.argv[3], process.argv[4]);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "~0.2.5",
     "rimraf": "~2.2.8",
+    "tiny-lr": "^0.1.5",
     "chalk": "~0.5.1",
     "broccoli": "~0.13.3"
   },


### PR DESCRIPTION
I know this seems to have been a somewhat controversial topic when it was up for discussion in #9, but I definitely think there's a use case where `broccoli serve` isn't enough to emulate a web app's server, yet you still want the incremental builds for the front-end, with LiveReload integration. I've taken the LiveReload code more or less directly from broccoli's source code. Hoping that this could gain some more traction in the form of a PR!

Also, a few more lines than were altered in theory were changed in practice due to = alignment and some trailing whitespace.