### PR TITLE
Write detailed error to the output and also generate a JSON dump file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "javascript"
   ],
   "dependencies": {
+    "broccoli": "file:../broccoli",
     "broccoli-kitchen-sink-helpers": "~0.2.5",
-    "rimraf": "~2.2.8",
     "chalk": "~0.5.1",
-    "broccoli": "~0.13.3"
+    "rimraf": "~2.2.8"
   },
   "devDependencies": {
     "mocha": "~2.1.0",


### PR DESCRIPTION
Hi!
I extended this utility to show a detailed output in case of errors.

Additionally, it also dumps the error in a JSON file on the current directory (that is removed on process exit or after a successful build). The usage of this is to make other server processes (in my case is Rails) to be aware that the process failed and therefore behave like the assets pipeline and raise a error on the browser.

Hope you're gonna like it.
See ya!
  Paolo