### PR TITLE
Show file changed, add broccoli-sane-watcher and watchman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,51 @@
 
 It's what you use to watch things, you know?
 
-OK, seriously, broccoli-timepiece is a command line utlility that uses the Watcher and Builder that
-come with `broccoli` to provide rebuild semantics without running a webserver.
+OK, seriously, broccoli-timepiece is a command line utility that uses the `broccoli-sane-watcher` and Builder that come with `broccoli` to provide rebuild semantics without running a webserver.
 
 ## Usage
 
 Uses the standard `broccoli` watcher to build a tree (from the `Brocfile.js` in your projects root), and output to a directory.
 
-Pass the name of the directory to output to as the first commandline parameter.
+Pass the name of the directory to output to as the first command line parameter.
 
 ```bash
 npm install -g broccoli-timepiece
 broccoli-timepiece dist/
+```
+
+### Options
+
+#### Verbose
+
+When passing `--verbose` (or `-v`) you will also see which file triggered the rebuild action, accompanied with the `Slowest Trees` output. Useful for tracking down where bottle necks are present.
+
+```bash
+broccoli-timepiece dist/ --verbose
+
+file changed css/style.scss
+Build successful - 1967ms
+
+Slowest Trees                                 | Total
+----------------------------------------------+---------------------
+AutoprefixerFilter                            | 748ms
+CoreObject                                    | 429ms
+SassCompiler                                  | 418ms
+SassCompiler                                  | 372ms
+
+Slowest Trees (cumulative)                    | Total (avg)
+----------------------------------------------+---------------------
+SassCompiler (2)                              | 790ms (395 ms)
+AutoprefixerFilter (1)                        | 748ms
+CoreObject (1)                                | 429ms
+```
+
+#### Watchman
+
+Considered a more reliable alternative when it comes to watching file changes. Requires `watchman` to be installed prior (`brew install watchman` if you are on OS X). Activated by passing either `--watchman` or `-w`. [More information about `watchman`](https://facebook.github.io/watchman/).
+
+```bash
+broccoli-timepiece dist/ --watchman
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   },
   "keywords": [
     "broccoli-plugin",
-    "javascript"
+    "javascript",
+    "watch",
+    "watcher",
+    "sane"
   ],
   "dependencies": {
     "broccoli": "^0.16.9",
@@ -23,12 +26,10 @@
     "broccoli-sane-watcher": "^1.1.4",
     "chalk": "^1.1.1",
     "minimist": "^1.2.0",
-    "mocha": "^2.4.5",
     "rimraf": "^2.5.2"
   },
   "devDependencies": {
-    "mocha": "~2.1.0",
-    "rimraf": "~2.2.8",
+    "mocha": "^2.4.5",
     "expect.js": "~0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
     "javascript"
   ],
   "dependencies": {
-    "broccoli-kitchen-sink-helpers": "~0.2.5",
-    "rimraf": "~2.2.8",
-    "chalk": "~0.5.1",
-    "broccoli": "~0.13.3"
+    "broccoli": "^0.16.9",
+    "broccoli-kitchen-sink-helpers": "^0.3.1",
+    "broccoli-sane-watcher": "^1.1.4",
+    "chalk": "^1.1.1",
+    "minimist": "^1.2.0",
+    "mocha": "^2.4.5",
+    "rimraf": "^2.5.2"
   },
   "devDependencies": {
     "mocha": "~2.1.0",


### PR DESCRIPTION
As I was looking to add support to show which file caused a rebuild action I ended up switching watcher to `broccoli-sane-watcher`. The closest I came with the built in `Watcher` was to show which folder had a change in it.

To allow for some of the features (`watchman` and `verbose`) available in `broccoli-sane-watcher` I added `minimist` to deal with the arguments passed in. Also a simple error message is showing when no directory is given.

All node dependencies were updated to their latest version too.

`README.md` has been updated to reflect the changes.

Fixes #16 
