### PR TITLE
Update to Broccoli 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,27 @@
 
 It's what you use to watch things, you know?
 
-OK, seriously, broccoli-timepiece is a command line utlility that uses the Watcher and Builder that
+OK, seriously, broccoli-timepiece is a command line utility that uses the Watcher and Builder that
 come with `broccoli` to provide rebuild semantics without running a webserver.
 
 ## Usage
 
 Uses the standard `broccoli` watcher to build a tree (from the `Brocfile.js` in your projects root), and output to a directory.
 
-Pass the name of the directory to output to as the first commandline parameter.
+Pass the name of the directory to output to as the first command line parameter.
 
 ```bash
 npm install -g broccoli-timepiece
 broccoli-timepiece dist/
 ```
+
+### Options
+
+Options can be specified before the destination directory.
+
+* `-v`, `--verbose`: Outputs the Slowest Trees information after successful builds.
+* `-w`, `--watchman`: Uses Facebook Watchman. Requires `watchman` to be installed.
+* `-p`, `--poll <milliseconds>`: Uses sane's polling mode at the specified interval.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -4,36 +4,42 @@ var fs       = require('fs');
 var path     = require('path');
 var chalk    = require('chalk');
 var rimraf   = require('rimraf');
-var helpers  = require('broccoli-kitchen-sink-helpers');
-var Watcher  = require('broccoli/lib/watcher');
+var copyDereferenceSync = require('copy-dereference').sync;
 var broccoli = require('broccoli');
+var printSlowNodes = require('broccoli-slow-trees');
+var program = require('commander');
 
-function createWatcher(destDir, interval) {
+function createWatcher(destDir, options) {
   var tree    = broccoli.loadBrocfile();
   var builder = new broccoli.Builder(tree);
-  var watcher = new Watcher(builder, {interval: interval || 100});
-
-  var atExit = function() { 
-    builder.cleanup()
-      .then(function() {
-        rimraf.sync("./broccoli-timepiece-failure.json");
-        process.exit(1);
-      });
+  var saneOptions = {
+      watchman: options.watchman === true,
+      poll: options.poll !== undefined,
+      interval: options.poll
   };
-  
+  var watcher = new broccoli.Watcher(builder, {saneOptions: saneOptions});
+
+  var atExit = function() {
+    watcher.quit();
+    rimraf.sync("./broccoli-timepiece-failure.json");
+  };
+
   process.on('SIGINT', atExit);
   process.on('SIGTERM', atExit);
 
-  watcher.on('change', function(results) {
+  watcher.on('buildSuccess', function(results) {
     rimraf.sync(destDir);
     rimraf.sync("./broccoli-timepiece-failure.json");
 
-    helpers.copyRecursivelySync(results.directory, destDir);
+    copyDereferenceSync(builder.outputPath, destDir);
 
-    console.log(chalk.green("Build successful - " + Math.floor(results.totalTime / 1e6) + 'ms'));
+    if (options.verbose) {
+        printSlowNodes(builder.outputNodeWrapper);
+    }
+    console.log(chalk.green("Build successful - " + builder.outputNodeWrapper.buildState.totalTime + 'ms'));
   });
 
-  watcher.on('error', function(error) {
+  watcher.on('buildFailure', function(error) {
     // Output to the console
     console.log(chalk.red('\n\nBuild failed.'));
 
@@ -55,7 +61,7 @@ function createWatcher(destDir, interval) {
 
     // Write a JSON dump file
     rimraf.sync("./broccoli-timepiece-failure.json");
-    fs.appendFile("./broccoli-timepiece-failure.json", JSON.stringify({
+    fs.appendFileSync("./broccoli-timepiece-failure.json", JSON.stringify({
       message: error.message,
       file: error.file,
       treeDir: error.treeDir,
@@ -65,7 +71,35 @@ function createWatcher(destDir, interval) {
     }, null, 2));
   });
 
+  watcher.start()
+    .catch(function(err) {
+      console.log(err && err.stack || err)
+    })
+    .finally(function() {
+      builder.cleanup()
+    })
+    .catch(function(err) {
+      console.log('Cleanup error:')
+      console.log(err && err.stack || err)
+    })
+    .finally(function() {
+      process.exit(1)
+    });
+
   return watcher;
 }
 
-createWatcher(process.argv[2], process.argv[3]);
+program
+  .version(JSON.parse(fs.readFileSync(__dirname + '/package.json', 'utf8')).version)
+  .usage('[options] <destination>')
+  .option('-v, --verbose', 'Enable verbose output')
+  .option('-w, --watchman', 'Use the Watchman watcher')
+  .option('-p, --poll <interval>', 'Use the polling watcher at the specified interval in milliseconds', parseInt)
+  .parse(process.argv);
+
+if (!program.args.length) {
+  program.help();
+  process.exit(1);
+}
+
+createWatcher(program.args[0], program);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-timepiece",
-  "version": "0.3.0",
+  "version": "1.0.0-alpha",
   "description": "Command line application using Broccoli to rebuild on file changes.",
   "main": "index.js",
   "author": "Robert Jackson",
@@ -18,10 +18,12 @@
     "javascript"
   ],
   "dependencies": {
-    "broccoli-kitchen-sink-helpers": "~0.2.5",
-    "rimraf": "~2.2.8",
-    "chalk": "~0.5.1",
-    "broccoli": "~0.13.3"
+    "copy-dereference": "^1.0",
+    "rimraf": "^2.5.2",
+    "chalk": "^1.1.1",
+    "broccoli": "^1.0.0",
+    "commander": "^2.5.0",
+    "broccoli-slow-trees": "^2.0"
   },
   "devDependencies": {
     "mocha": "~2.1.0",


### PR DESCRIPTION
I've made the necessary changes to get broccoli-timepiece running with Broccoli 1.1. 

* Use `copy-dereference` instead of `broccoli-kitchen-sink-helpers`
* Use new native `Builder` and `Watcher` APIs in Broccoli core
* Added dependency on `broccoli-slow-trees` for verbose output
* Added dependency on `commander` (like Broccoli itself has) to help out with CLI arguments

This script now supports all of:
1. The native sane file watch mode
2. The Facebook watchman mode
3. The interval polling mode